### PR TITLE
Removed and renamed species

### DIFF
--- a/Resources/Locale/en-US/_DV/species/species.ftl
+++ b/Resources/Locale/en-US/_DV/species/species.ftl
@@ -1,6 +1,6 @@
 ## Species Names
 
-species-name-oni = Oni
+species-name-oni = Ghav
 species-name-felinid = Felinid
 species-name-vulpkanin = Vulpkanin
 species-name-harpy = Harpy

--- a/Resources/Locale/en-US/species/species.ftl
+++ b/Resources/Locale/en-US/species/species.ftl
@@ -2,7 +2,7 @@
 
 species-name-human = Human
 species-name-dwarf = Dwarf
-species-name-reptilian = Reptilian
+species-name-reptilian = Draconic
 species-name-slime = Slime Person
 species-name-diona = Diona
 species-name-arachnid = Arachnid

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -12,7 +12,7 @@
     - id: GlimmerRevenantSpawn
     - id: GlimmerMiteSpawn
     - id: GlimmerRandomSentience
-    - id: ThavenMoodUpset
+    #- id: ThavenMoodUpset # Quantum Blue: Thavens removed for now, but leaving the code intact just in case
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_DV/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Species/chitinid.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Chitinid
   name: species-name-chitinid
-  roundStart: true
+  roundStart: false # Quantum Blue: Removing Chitinid as a playable species
   prototype: MobChitinid
   sprites: MobChitinidSprites
   defaultSkinTone: "#ffda93"

--- a/Resources/Prototypes/_DV/Species/feroxi.yml
+++ b/Resources/Prototypes/_DV/Species/feroxi.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Feroxi
   name: species-name-feroxi
-  roundStart: true
+  roundStart: false # Quantum Blue: Removing Feroxi as a playable species
   prototype: MobFeroxi
   sprites: MobFeroxiSprites
   defaultSkinTone: "#8DB9D6"

--- a/Resources/Prototypes/_DV/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Species/harpy.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Harpy
   name: species-name-harpy
-  roundStart: true
+  roundStart: false # Quantum Blue: Removed Harpy as a playable species
   prototype: MobHarpy
   sprites: MobHarpySprites
   markingLimits: MobHarpyMarkingLimits

--- a/Resources/Prototypes/_DV/Species/kitsune.yml
+++ b/Resources/Prototypes/_DV/Species/kitsune.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Kitsune
   name: Kitsune
-  roundStart: true
+  roundStart: false # Quantum Blue: Kitsune no longer playable
   prototype: MobKitsune
   sprites: MobHumanSprites
   markingLimits: MobKitsuneMarkingLimits

--- a/Resources/Prototypes/_Impstation/Species/thaven.yml
+++ b/Resources/Prototypes/_Impstation/Species/thaven.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Thaven
   name: species-name-thaven
-  roundStart: true
+  roundStart: false # Quantum Blue: Thaven no longer playable
   prototype: MobThaven
   sprites: MobThavenSprites
   defaultSkinTone: "#ffffff"


### PR DESCRIPTION
Made Chitinid, Feroxi, Harpy, Kitsune, and Thaven no longer playable, as well as renaming Oni to Ghav, and Reptilian to Draconic.
Oh and Thaven mood shift glimmer was removed, since it doesn't do anything anymore.
