### PR TITLE
AI Camera speed increase

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -326,6 +326,9 @@
   description: The AI's viewer.
   categories: [ HideSpawnMenu, DoNotMap ]
   components:
+  - type: MovementSpeedModifier # Quantum Blue: Made the station ai camera x2 faster
+    baseWalkSpeed: 12
+    baseSprintSpeed: 24
   - type: NoFTL
   - type: Tag
     tags:


### PR DESCRIPTION
Doubled the "walk" and "sprint" speed of the station AI's camera view. (12 and 24 respectively, from the previous 6 and 12)

:cl:
- tweak: Doubled the movement speed of the AI's camera view
