### PR TITLE
Remove service worker and prisoner as round start roles

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
@@ -8,6 +8,7 @@
   canBeAntag: false
 #  whitelistRequired: true
   icon: "JobIconPrisoner"
+  setPreference: false
   supervisors: job-supervisors-security
   requirements:
     - !type:DepartmentTimeRequirement

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -9,6 +9,7 @@
     time: 1800 #0.5 hr
   startingGear: ServiceWorkerGear
   icon: "JobIconServiceWorker"
+  setPreference: false
   supervisors: job-supervisors-service
   access:
   - Service


### PR DESCRIPTION
They still exist, you just can't pick em.