### PR TITLE
Manual death gasp is back

### DIFF
--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -322,8 +322,8 @@
     components:
     - MobState
   chatMessages: ["chat-emote-msg-deathgasp"]
-  # chatTriggers: # DeltaV - Remove from the emote wheel
-  # - deathgasp
+  chatTriggers:
+   - deathgasp
 
 - type: emote
   id: MonkeyDeathgasp


### PR DESCRIPTION
Does what it says! You can death gasp on the emote wheel or with the "deathgasp" chat trigger like you could in the past. Deceit is fun!